### PR TITLE
Implement dry run and style TXSourceString properly

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/transifex/transifex-swift",
         "state": {
           "branch": null,
-          "revision": "a326fbf8bc8023b8cc09f31beffebf82faadeebc",
-          "version": "0.1.0"
+          "revision": "47d47d4eee281da15721285b86f75539d4061fff",
+          "version": "0.5.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(name: "transifex",
                  url: "https://github.com/transifex/transifex-swift",
-                 from: "0.1.0"),
+                 from: "0.5.0"),
         .package(url: "https://github.com/apple/swift-argument-parser",
                  from: "0.3.0"),
     ],

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ The following calls can be either made from within the `TXCli` project directory
 or after following the installation instructions above,  from any folder of your computer by:
 `txios-cli <cli command>`.
 
+Bear in mind that due to naming collision, the `--verbose` flag won't be detected if the
+`txios-cli` is executed via the `swift run` command, as the flag will be applied on the 
+`swift` executable instead. So to avoid collisions like this, it's recommended to execute
+`txios-cli` directly after building it.
+
 For simplicity the following examples will use the latter command.
 
 #### Help

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -104,6 +104,9 @@ the CDS server.
 """)
     private var tags: [String] = []
     
+    @Flag(name: .long, help: "Do not push to CDS.")
+    private var dryRun: Bool = false
+    
     func run() throws {
         let logHandler = CliLogHandler()
         logHandler.verbose = options.verbose
@@ -183,6 +186,17 @@ the CDS server.
             
             translations.append(translationUnit)
         }
+        
+        logHandler.info("""
+[high]Found[end] [num]\(translations.count)[end] [high]source strings[end]
+""")
+        
+        guard dryRun == false else {
+            logHandler.warning("[warn]Dry run: no strings will be pushed to CDS")
+            
+            logHandler.verbose("Translations: \(translations.debugDescription)")
+            return
+        }
 
         logHandler.verbose("[high]Initializing TxNative...[end]")
         
@@ -234,7 +248,8 @@ or via the --token parameter.
 
     @Option(name: .long, parsing: .upToNextOption, help: """
 A list of the available locales that the application supports and will be
-downloaded from CDS. The source locale, if added, is ignored.
+downloaded from CDS. If both source and target locales are provided in the list,
+they will also be requested from CDS.
 """)
     private var translatedLocales: [String]
     

--- a/Sources/TXCliLib/CliLogHandler.swift
+++ b/Sources/TXCliLib/CliLogHandler.swift
@@ -41,6 +41,36 @@ public class CliLogHandler: TXLogHandler {
     }
 }
 
+/// Extension responsible for printing the debug description of a TXSourceString to the console with proper
+/// styling.
+extension TXSourceString {
+    public override var debugDescription: String {
+        var description = "\n"
+        
+        description += "[green]\"\(sourceString)\"[end]\n"
+
+        if let context = context {
+            description += "[high]context:[end] \(context.debugDescription)\n"
+        }
+
+        if let developerComment = developerComment {
+            description += "[high]comment:[end] \(developerComment)\n"
+        }
+
+        if characterLimit > 0 {
+            description += "[high]character limit:[end] \(characterLimit)\n"
+        }
+
+        if let tags = tags, tags.count > 0 {
+            description += "[high]tags:[end] \(tags.joined(separator: ", "))\n"
+        }
+        
+        description += "   [high]occurrences:[end] [file]\(occurrences.joined(separator: ", "))[end]\n"
+
+        return description
+    }
+}
+
 /// Convenience class for adding color to console output.
 class CliSyntaxColor {
     static let WHITE_BOLD = "\u{001B}[0;1m"


### PR DESCRIPTION
1. Updates `README` with clarification regarding the `verbose` argument
conflict when running the CLI tool using the `swift run` command.
2. Adds `dryRun` flag so that the CLI tool won't actually send anything
to CDS, which is useful for testing the command.
3. Removes the comment regarding ignoring the source locale when pulling
strings from the CDS.
4. Styles the `TXSourceString` instances when printed (via the
`debugDescription` property) accordingly.

3. Depends on https://github.com/transifex/transifex-swift/pull/28
4. Depends on https://github.com/transifex/transifex-swift/pull/29