### PR TITLE
Update CDSHandler logic to v2

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ devel ]
+    branches: [ master ]
   pull_request:
-    branches: [ devel ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,13 @@
 - Changes `--tags` to `--append-tags` for push command.
 - Allows content to pulled with specific tags in pull command.
 - Formats found strings on push command correctly.
+
+## Transifex Command Line Tool 1.0.0
+
+*July 29, 2021*
+
+- Updates Transifex Swift library to 1.0.0.
+- Adds initial value to `withTagsOnly` argument so that is not required.
+- Displays custom message when max retries have been exhausted during the push operation.
+- Uses animated cursor from CLISpinner library while waiting for a response from CDS when
+verbose flag is not provided.

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "CLISpinner",
+        "repositoryURL": "https://github.com/kiliankoe/CLISpinner",
+        "state": {
+          "branch": null,
+          "revision": "0572232b92ddfd80cbab4ced6973d1c210022968",
+          "version": "0.4.0"
+        }
+      },
+      {
+        "package": "Rainbow",
+        "repositoryURL": "https://github.com/onevcat/Rainbow",
+        "state": {
+          "branch": null,
+          "revision": "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
+          "version": "3.2.0"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/transifex/transifex-swift",
         "state": {
           "branch": null,
-          "revision": "47d47d4eee281da15721285b86f75539d4061fff",
-          "version": "0.5.0"
+          "revision": "1a79564a8c51ef748c9f4a27fb3e3e10d6dbe9d0",
+          "version": "1.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(name: "transifex",
                  url: "https://github.com/transifex/transifex-swift",
-                 from: "0.5.0"),
+                 from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser",
                  from: "0.3.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,8 @@ let package = Package(
                  from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser",
                  from: "0.3.0"),
+        .package(url: "https://github.com/kiliankoe/CLISpinner",
+                 from: "0.4.0")
     ],
     targets: [
         .target(
@@ -27,6 +29,7 @@ let package = Package(
                          package: "transifex"),
                 .product(name: "ArgumentParser",
                          package: "swift-argument-parser"),
+                "CLISpinner"
             ]
         ),
         .target(

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "0.1.0",
+        version: "1.0.0",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -263,7 +263,7 @@ will try to create it (alongside any intermediate folders).
     @Option(name: .long, parsing: .upToNextOption, help: """
 If set, only the strings that have all of the given tags will be downloaded.
 """)
-    private var withTagsOnly: [String]
+    private var withTagsOnly: [String] = []
     
     func run() throws {
         let logHandler = CliLogHandler()

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -10,6 +10,7 @@ import Transifex
 import TXCliLib
 import ArgumentParser
 import Foundation
+import CLISpinner
 
 /// All possible error codes that might trigger a failure during the execution of a TXCli command.
 enum CommandError : Error {
@@ -209,6 +210,11 @@ the CDS server.
 [high]Pushing[end] [num]\(translations.count)[end] [high]source strings to CDS ([end][prompt]Purge: \(purge ? "Yes" : "No")[end][high])...[end]
 """)
         
+        let spinner = Spinner(pattern: .dots, text: "Pushing")
+        if !options.verbose {
+            spinner.start()
+        }
+        
         // Block until the push logic completes using a semaphore.
         let semaphore = DispatchSemaphore(value: 0)
         var pushResult = false
@@ -222,6 +228,10 @@ the CDS server.
         }
         
         semaphore.wait()
+        
+        if !options.verbose {
+            spinner.stopAndClear()
+        }
         
         if !pushResult {
             if containsMaxRetriesReachedError(pushErrors) {
@@ -317,6 +327,11 @@ If set, only the strings that have all of the given tags will be downloaded.
         
         logHandler.info("[high]Fetching translations from CDS...[end]")
         
+        let spinner = Spinner(pattern: .dots, text: "Fetching")
+        if !options.verbose {
+            spinner.start()
+        }
+        
         // Block until the pull logic completes using a semaphore.
         let semaphore = DispatchSemaphore(value: 0)
         var appTranslations: [String: TXLocaleStrings] = [:]
@@ -329,6 +344,10 @@ If set, only the strings that have all of the given tags will be downloaded.
         }
         
         semaphore.wait()
+        
+        if !options.verbose {
+            spinner.stopAndClear()
+        }
         
         guard appErrors.count == 0 else {
             logHandler.error("Errors while fetching translations from CDS: \(appErrors)")

--- a/Sources/TXCliLib/CliLogHandler.swift
+++ b/Sources/TXCliLib/CliLogHandler.swift
@@ -44,6 +44,9 @@ public class CliLogHandler: TXLogHandler {
 /// Extension responsible for printing the debug description of a TXSourceString to the console with proper
 /// styling.
 extension TXSourceString {
+    /// Stylize the debug description of the TXSourceString for the CLI needs.
+    ///
+    /// We are aware of the 'method in category overrides method from class' warning(s) produced here.
     public override var debugDescription: String {
         var description = "\n"
         


### PR DESCRIPTION
- Adds initial value to `withTagsOnly` argument so that is not required.
- Updates Transifex Swift library to 1.0.0.
- Displays custom message when max retries have been exhausted during the push operation.
- Uses animated cursor from CLISpinner library while waiting for a response from CDS when
verbose flag is not provided.