### PR TITLE
Add option for controlling key hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,15 @@
 - Displays custom message when max retries have been exhausted during the push operation.
 - Uses animated cursor from CLISpinner library while waiting for a response from CDS when
 verbose flag is not provided.
+
+## Transifex Command Line Tool 1.0.1
+
+*September 24, 2021*
+
+- Introduces boolean flag pair (`--enable-hash-keys`/`--disable-hash-keys`) to 
+control whether the keys of strings to be pushed should be hashed or not. 
+By default the value of this option is `true`, so the keys will be hashed unless
+`--disable-hash-keys` is provided.
+- Translation keys are now printed next to the source string when `--dry-run`
+option is provided.
+- Updates Transifex Swift library to 1.0.1.

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/transifex/transifex-swift",
         "state": {
           "branch": null,
-          "revision": "1a79564a8c51ef748c9f4a27fb3e3e10d6dbe9d0",
-          "version": "1.0.0"
+          "revision": "7c1326b1a80fb37923cb4782d63293766ce8ffa7",
+          "version": "1.0.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(name: "transifex",
                  url: "https://github.com/transifex/transifex-swift",
-                 from: "1.0.0"),
+                 from: "1.0.1"),
         .package(url: "https://github.com/apple/swift-argument-parser",
                  from: "0.3.0"),
         .package(url: "https://github.com/kiliankoe/CLISpinner",

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "1.0.0",
+        version: "1.0.1",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -108,6 +108,12 @@ the CDS server.
     @Flag(name: .long, help: "Do not push to CDS.")
     private var dryRun: Bool = false
     
+    @Flag(name: .long, inversion: .prefixedEnableDisable,
+          exclusivity: .exclusive, help: """
+Control whether the keys of strings to be pushed should be hashed or not.
+""")
+    private var hashKeys: Bool = true
+
     func run() throws {
         let logHandler = CliLogHandler()
         logHandler.verbose = options.verbose
@@ -160,8 +166,8 @@ the CDS server.
         var translations: [TXSourceString] = []
         
         for result in XLIFFParser.consolidate(parser.results) {
-            let key = txGenerateKey(sourceString: result.id,
-                                    context: nil)
+            let key = hashKeys ? txGenerateKey(sourceString: result.id,
+                                               context: nil) : result.id
             
             // Get the .target instead of the .source of the result as user
             // might have localized the string for the base locale.

--- a/Sources/TXCliLib/CliLogHandler.swift
+++ b/Sources/TXCliLib/CliLogHandler.swift
@@ -50,6 +50,7 @@ extension TXSourceString {
     public override var debugDescription: String {
         var description = "\n"
         
+        description += "[yel]\"\(key)\"[end]: "
         description += "[green]\"\(sourceString)\"[end]\n"
 
         if let context = context {


### PR DESCRIPTION
* Introduces boolean flag pair (`--enable-hash-keys`/`--disable-hash-keys`) to control whether the keys of strings to be pushed should be hashed or not. By default the value of this option is `true`, so the keys will be hashed unless `--disable-hash-keys` is provided.
* Translation keys are now printed next to the source string when `--dry-run` option is provided.
* Updates Transifex Swift library to 1.0.1.