### PR TITLE
Stelios/improvement/xliff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,10 @@ By default the value of this option is `true`, so the keys will be hashed unless
 - Translation keys are now printed next to the source string when `--dry-run`
 option is provided.
 - Updates Transifex Swift library to 1.0.1.
+
+## Transifex Command Line Tool 1.0.2
+
+*October 26, 2021*
+
+- Introduces parsing directly from an `.xliff` file using the `--project`
+argument of the push command.

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "1.0.1",
+        version: "1.0.2",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 


### PR DESCRIPTION
The `--project` argument of the push command now also supports parsing
directly from an `.xliff` file, allowing anyone with access to the
generated `.xliff` file to push strings to CDS.

This can be helpful if access to the source code of the project is not
available or if the step that performs the automatic XLIFF generation
from the Xcode project has to be skipped for some reason.

If instead of the `.xliff` file, the path to the `.xcodeproj` container
is provided, the logic will behave exactly as before.