### PR TITLE
Address special chars issue + update version to 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,9 @@ argument of the push command.
 *January 14, 2021*
 
 - Fixes regression introduced in 1.0.2 regarding the temporary directory that stores the XLIFF structure being removed prematurely.
+
+## Transifex Command Line Tool 1.0.4
+
+*March 15, 2022*
+
+- Fixes issue where special characters in XLIFF were not producing correct source strings.

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "1.0.3",
+        version: "1.0.4",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 

--- a/Sources/TXCliLib/XLIFFParser.swift
+++ b/Sources/TXCliLib/XLIFFParser.swift
@@ -62,15 +62,15 @@ public struct PluralizationRule {
     }
     
     mutating func updateSource(_ inSource: String) {
-        source = inSource
+        source = (source ?? "") + inSource
     }
     
     mutating func updateTarget(_ inTarget: String) {
-        target = inTarget
+        target = (target ?? "") + inTarget
     }
     
     mutating func updateNote(_ inNote: String) {
-        note = inNote
+        note = (note ?? "") + inNote
     }
     
     /// Parses the id attribute of the `trans-unit` XML tag, removes the types and trims the slash
@@ -206,6 +206,18 @@ public class XLIFFParser: NSObject {
         var note: String?
         var file: String?
         var pluralizationRules: [PluralizationRule] = []
+        
+        mutating func updateSource(_ inSource: String) {
+            source = (source ?? "") + inSource
+        }
+        
+        mutating func updateTarget(_ inTarget: String) {
+            target = (target ?? "") + inTarget
+        }
+        
+        mutating func updateNote(_ inNote: String) {
+            note = (note ?? "") + inNote
+        }
     }
     
     /// The underlying XML parser
@@ -496,7 +508,7 @@ extension XLIFFParser : XMLParserDelegate {
                 activePluralizationRule?.updateSource(string)
             }
             else {
-                activeTranslationUnit?.source = string
+                activeTranslationUnit?.updateSource(string)
             }
         }
         else if activeElement == XLIFFParser.XML_TARGET_NAME {
@@ -504,7 +516,7 @@ extension XLIFFParser : XMLParserDelegate {
                 activePluralizationRule?.updateTarget(string)
             }
             else {
-                activeTranslationUnit?.target = string
+                activeTranslationUnit?.updateTarget(string)
             }
         }
         else if activeElement == XLIFFParser.XML_NOTE_NAME {
@@ -512,7 +524,7 @@ extension XLIFFParser : XMLParserDelegate {
                 activePluralizationRule?.updateNote(string)
             }
             else {
-                activeTranslationUnit?.note = string
+                activeTranslationUnit?.updateNote(string)
             }
         }
     }

--- a/Tests/TXCliTests/XLIFFParserTests.swift
+++ b/Tests/TXCliTests/XLIFFParserTests.swift
@@ -217,9 +217,52 @@ final class XLIFFParserTests: XCTestCase {
         XCTAssertEqual(icuRule, expectedIcuRule)
     }
     
+    func testXLIFFParserWithQuotes() {
+        let fileURL = tempXLIFFFileURL()
+        let sampleXLIFF = """
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+  <file original="Localizable.strings" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.3" build-num="12C33"/>
+    </header>
+    <body>
+      <trans-unit id="vyW-d6-PC8.text" xml:space="preserve">
+        <source>We’re réa`dy!</source>
+        <target>We’re réa`dy!</target>
+        <note>Class = "UILabel"; text = "We’re réa`dy!"; ObjectID = "vyW-d6-PC8";</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+"""
+        do {
+            try sampleXLIFF.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+        catch { }
+        
+        let xliffParser = XLIFFParser(fileURL: fileURL)
+        XCTAssertNotNil(xliffParser, "Failed to initialize parser")
+
+        let parsed = xliffParser!.parse()
+
+        XCTAssertTrue(parsed)
+
+        let results = xliffParser!.results
+
+        XCTAssertTrue(results.count == 1)
+
+        let result = results.first!
+        
+        XCTAssertEqual(result.source, "We’re réa`dy!")
+        
+        XCTAssertEqual(result.target, "We’re réa`dy!")
+    }
+    
     static var allTests = [
         ("testXLIFFParser", testXLIFFParser),
         ("testXLIFFParserWithStringsDict", testXLIFFParserWithStringsDict),
         ("testXLIFFResultConsolidation", testXLIFFResultConsolidation),
+        ("testXLIFFParserWithQuotes", testXLIFFParserWithQuotes),
     ]
 }


### PR DESCRIPTION
### Parse strings with special characters correctly

When a source string contained a special character (e.g. a quote), the
parsing was dropping all characters before that special character,
losing part of the string.

In this commit, we ensure that we append to the active translation unit
instead of overwriting it, which updates the currently parsed string
correctly.

A new unit test has been added to test against this particular case
using a number of different special characters.

---

### Bumps version to 1.0.4

* Bumps CLI version to 1.0.4.
* Updates the CHANGELOG.