### PR TITLE
Address project parameter to allow `.xcworkspace` + update version to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,10 @@ argument of the push command.
 *March 15, 2022*
 
 - Fixes issue where special characters in XLIFF were not producing correct source strings.
+
+## Transifex Command Line Tool 1.0.5
+
+*October 25, 2022*
+
+- Allows users to enter a `.xcworkspace` as a `project` argument and handles it correctly.
+

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -80,7 +80,7 @@ You can either provide the Transifex token and secret via enviroment variables
     private var sourceLocale: String = "en"
 
     @Option(name: .long, help: """
-Either the path to the project's .xcodeproj (e.g. ../MyProject/myproject.xcodeproj),
+Either the path to the project's .xcodeproj or .xcworkspace (e.g. ../MyProject/myproject.xcodeproj),
 or the path to the generated .xliff (e.g. ../en.xliff).
 """)
     private var project : String
@@ -135,7 +135,7 @@ Control whether the keys of strings to be pushed should be hashed or not.
         logHandler.verbose("[prompt]Using secret: \(transifexSecret)[end]")
         
         var xliffURL : URL? = nil
-        let url = URL(fileURLWithPath: project)
+        let projectURL = URL(fileURLWithPath: project)
         
         var localizationExporter : LocalizationExporter? = nil
         
@@ -145,14 +145,14 @@ Control whether the keys of strings to be pushed should be hashed or not.
             }
         }
         
-        if url.pathExtension == "xliff" {
-            xliffURL = url
+        if projectURL.pathExtension == "xliff" {
+            xliffURL = projectURL
             logHandler.verbose("[prompt]XLIFF file detected: \(xliffURL!)[end]")
         }
         else {
             guard let locExporter = LocalizationExporter(sourceLocale: sourceLocale,
-                                                                  project: project,
-                                                                  logHandler: logHandler) else {
+                                                         project: projectURL,
+                                                         logHandler: logHandler) else {
                 logHandler.error("Failed to initialize localization exporter")
                 throw CommandError.exporterInitializationFailure
             }

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "1.0.4",
+        version: "1.0.5",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 


### PR DESCRIPTION
### Support xcworkspace on project parameter

The cli tool was not detecting the `.xcworkspace` projects, leading to
cases where users had to provide the `.xcodeproj` file instead but that
does not always work, as the underlying `xcodebuild` tool will try to
build the project, missing all dependencies that may be needed.

This commit makes it possible for the cli tool to detect when users
provide a `.xcworkspace` instead of a `.xcodeproj` and use the correct
argument for the `xcodebuild` tool.

The help string has been also updated to reflect that change and the
logic now fails earlier if users provide a file that is neither a
`.xliff`, `.xcodeproj` or a `.xcworkspace` one.

---

### Bump version to 1.0.5

* Bumps CLI version to 1.0.5.
* Updates the CHANGELOG.