### PR TITLE
Push improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,19 @@ argument of the push command.
 *February 23, 2023*
 
 - Introduces status filter option in pull command.
+
+## Transifex Command Line Tool 2.0.0
+
+*July 7, 2023*
+
+- `push` command now logs any warnings and errors generated during the
+processing and push of the source strings.
+- Source strings that only exist in files not supported by Transifex SDK are
+now ommited.
+- Extra options have been introduced for the `push` command:
+`--override-tags`, `--override-occurrences`, `--keep-translations`.
+- Push logic detects and reports warnings such as duplicate source string keys
+or empty source string keys.
+- The default value for the `hashKeys` option of the `push` command has been
+flipped, so by default the tool **does not** hash the keys of the provided
+source strings, respecting the original keys passed by the developer.

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/transifex/transifex-swift",
         "state": {
           "branch": null,
-          "revision": "bb5067a395e7343a9c5697bb365baffff3d178f8",
-          "version": "1.0.4"
+          "revision": "aa97b51b642f3865cc9810d7e07ab2d33d6db215",
+          "version": "2.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(name: "transifex",
                  url: "https://github.com/transifex/transifex-swift",
-                 from: "1.0.4"),
+                 from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser",
                  from: "0.3.0"),
         .package(url: "https://github.com/kiliankoe/CLISpinner",

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -101,7 +101,7 @@ the CDS server.
 Control whether the keys of strings to be pushed should be hashed (true) or not
 (false).
 """)
-    private var hashKeys: Bool = true
+    private var hashKeys: Bool = false
 
     @Flag(name: .long, help: """
 If purge: true, then replace the entire resource content with the pushed content

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "1.0.6",
+        version: "2.0.0",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 

--- a/Sources/TXCliLib/CliLogHandler.swift
+++ b/Sources/TXCliLib/CliLogHandler.swift
@@ -21,11 +21,35 @@ public class CliLogHandler: TXLogHandler {
     }
     
     public func warning(_ message: String) {
-        log(message)
+        warning(message, trailingLine: false)
+    }
+
+    public func warning(_ message: String, trailingLine: Bool = false) {
+        if trailingLine {
+            log("""
+[prompt]\(message)[end]
+
+""")
+        }
+        else {
+            log("[prompt]\(message)[end]")
+        }
     }
     
     public func error(_ message: String) {
-        log("[error]\(message)[end]")
+        error(message, trailingLine: false)
+    }
+
+    public func error(_ message: String, trailingLine: Bool = false) {
+        if trailingLine {
+            log("""
+[error]\(message)[end]
+
+""")
+        }
+        else {
+            log("[error]\(message)[end]")
+        }
     }
     
     public func verbose(_ message: String) {

--- a/Sources/TXCliLib/XLIFFParser.swift
+++ b/Sources/TXCliLib/XLIFFParser.swift
@@ -300,7 +300,37 @@ public class XLIFFParser: NSObject {
         
         return true
     }
-    
+
+    private static let EXCLUDE_FILENAMES = [
+        "InfoPlist.strings",
+        "Root.strings"
+    ]
+
+    /// Filters results by excluding translation units that their `files` array lists filenames that cannot be
+    /// handled by the Transifex SDK (`EXCLUDE_FILENAMES`).
+    ///
+    /// If the `files` array includes a filename that is not part of the above array, then that translation
+    /// unit is not filtered out.
+    ///
+    /// Ref: https://transifex.github.io/transifex-swift/#special-cases
+    ///
+    /// - Parameter results: The parser results
+    /// - Returns: Array of filtered results that do not contain translation units that are included in the
+    /// `SKIP_FILENAMES` files.
+    public static func filter(_ results: [TranslationUnit]) -> [TranslationUnit] {
+        return results.filter { translationUnit in
+            var excludedFilenameCount = 0
+            for file in translationUnit.files {
+                for excludeFilename in EXCLUDE_FILENAMES {
+                    if file.contains(excludeFilename) {
+                        excludedFilenameCount += 1
+                    }
+                }
+            }
+            return excludedFilenameCount != translationUnit.files.count
+        }
+    }
+
     /// Consolidates results based on their ID and combines their properties if needed.
     ///
     /// Call this method after parse() call was successful.


### PR DESCRIPTION
### Point Transifex package to 2.0.0

Points the Transifex package to 2.0.0

---

### Push command improvements

* Parser results are now first filtered to remove any strings that
are only included in files not supported by Transifex iOS SDK, namely
`Info.plist` and `Root.plist` files (more here
https://transifex.github.io/transifex-swift/#special-cases). This is
a separate static method in `XLIFFParser` class (`filter(results:)`).
* Uses the updated `pushTranslation()` method that reports back the
number of generated warnings during the processing of the source
strings. Those warnings are now logged individually. The errors are
also now logged individually.

---

### Introduce new options in push command

Introduces the following options in the push command:

`--override-tags`, `--override-occurrences`, `--keep-translations`

Also `--dry-run` is passed to the CDS network request now instead of
being handled locally.

---

### Flip hash keys option value

Flips the default `hashKeys` option value for the `push` command from
`true` to `false` so that, by default, CLI will not hash the keys of
the source strings to be pushed, preserving the original keys added by
the developer

---

### Bump version to 2.0.0

* Bumps CLI version to 2.0.0.
* Updates the CHANGELOG.
