### PR TITLE
Introduce excluded files option

### DIFF
--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -96,6 +96,12 @@ the CDS server.
 """)
     private var appendTags: [String] = []
     
+    @Option(name: .long, parsing: .upToNextOption, help: """
+An optional list of localizable files that the logic must exclude when
+processing the exported strings.
+""")
+    private var excludedFiles: [String] = []
+
     @Flag(name: .long, inversion: .prefixedEnableDisable,
           exclusivity: .exclusive, help: """
 Control whether the keys of strings to be pushed should be hashed (true) or not
@@ -213,7 +219,12 @@ Emulate a content push, without doing actual changes.
             throw CommandError.xliffParsingFailure
         }
         
-        let filteredResults = XLIFFParser.filter(parser.results)
+        var excludeFilenames = XLIFFParser.UNSUPPORTED_FILES
+        excludeFilenames.append(contentsOf: excludedFiles)
+
+        let filteredResults = XLIFFParser.filter(parser.results,
+                                                 excludeFilenames: excludedFiles,
+                                                 logHandler: logHandler)
 
         var translations: [TXSourceString] = []
         


### PR DESCRIPTION
Introduces the `--excluded-files` option in the `push` command so that users can offer an optional list of filenames that the internal logic must exclude when processing the intermediate XLIFF file.

Developers can offer a comma separated list of filenames that must be filtered out by the CLI before the strings are pushed to CDS.

Example:

```
txios-cli push ... --excluded-files ExcludedFile1.strings,ExcludedFile2.strings
```

Note: If a string is included both in the excluded filenames and is also found in non-excluded filenames, it will be included in the push data.

Internally, the logic appends this optional list to the list of unsupported files that is already being filtered out.

The filtered strings are logged in case user has enabled the verbose logging option.