### PR TITLE
Correct wording regarding excluded-files option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ command can be simplified to:
 
 With the `--excluded-files` option in the `push` command, an optional list of filenames can be excluded from processing.
 
-Developers can offer a comma separated list of filenames that must be filtered out by the CLI before the strings are pushed to CDS.
+Developers can offer a space separated list of filenames that must be filtered out by the CLI before the strings are pushed to CDS.
 
 Example:
 
 ```
-txios-cli push ... --excluded-files ExcludedFile1.strings,ExcludedFile2.strings
+txios-cli push ... --excluded-files ExcludedFile1.strings ExcludedFile2.strings
 ```
 
 > Note: If a string is included both in the excluded filenames and is also found in non-excluded filenames, it will be included in the push data.


### PR DESCRIPTION
Fixes the wrong documentation regarding the
`--excluded-files` option of the `push` command
that accepts a space separated list of files
instead of a comma separated one.