### PR TITLE
Version 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,19 @@ source strings, respecting the original keys passed by the developer.
 - Extra option for the `push` command has been introduced: `--excluded-files`
 that excludes the provided filenames from processing, filtering out any included
 strings.
+
+## Transifex Command Line Tool 2.1.1
+
+*September 21, 2023*
+
+- Adds `--source-locale` option to `pull` command so that developers can specify
+the source locale, if it's different than `en`. If not provided, the `pull`
+logic default to the `en` source locale.
+- Fixes an issue on `push` command where the unsupported SDK files were not
+being excluded by the localization parsing logic.
+- Addresses language tag discrepancy: In the `push` command, the
+`--source-locale` option refers to the source locale of the Xcode project and
+the format used by Xcode and iOS is different than the format used by Transifex
+(e.g `en-US` instead of `en_US`). For that reason the source locale string is
+now normalized before being passed to the exporter logic so that the latter can
+always be able to export the source locale from the Xcode project.

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -462,6 +462,12 @@ This option can be used alongside the --with-tags-only option.
 """)
     private var withStatusOnly: String?
 
+    @Option(name: .long, help: """
+Provide a source locale if it is different than 'en'. Otherwise the logic will
+default to the 'en' source locale.
+""")
+    private var sourceLocale: String?
+
     func run() throws {
         let logHandler = CliLogHandler()
         logHandler.verbose = options.verbose
@@ -477,7 +483,7 @@ This option can be used alongside the --with-tags-only option.
         
         logHandler.info("[prompt]Initializing TxNative...[end]")
         
-        TXNative.initialize(locales: TXLocaleState(sourceLocale: nil,
+        TXNative.initialize(locales: TXLocaleState(sourceLocale: sourceLocale,
                                                    appLocales: translatedLocales),
                             token: transifexToken,
                             secret: nil,

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -223,7 +223,7 @@ Emulate a content push, without doing actual changes.
         excludeFilenames.append(contentsOf: excludedFiles)
 
         let filteredResults = XLIFFParser.filter(parser.results,
-                                                 excludeFilenames: excludedFiles,
+                                                 excludeFilenames: excludeFilenames,
                                                  logHandler: logHandler)
 
         var translations: [TXSourceString] = []

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "2.1.0",
+        version: "2.1.1",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 

--- a/Sources/TXCliLib/LocalizationExporter.swift
+++ b/Sources/TXCliLib/LocalizationExporter.swift
@@ -26,7 +26,10 @@ public class LocalizationExporter {
     private static let LOCALIZED_CONTENTS_FOLDER_NAME = "Localized Contents"
     private static let XCLOC_EXTENSION = "xcloc"
     private static let XLIFF_EXTENSION = "xliff"
-    
+
+    private static let IOS_LANGUAGE_TAG_DELIMITER = "-"
+    private static let TRANSIFEX_LANGUAGE_TAG_DELIMITER = "_"
+
     private let logHandler: TXLogHandler?
     
     /// Initializes the exporter and generates a temp directory for this session where the generated .xcloc
@@ -45,7 +48,13 @@ public class LocalizationExporter {
             return nil
         }
 
-        self.sourceLocale = sourceLocale
+        /// Ensure that the exported XLOC and XLIFF containers will be accessible for the source locale,
+        /// as the iOS uses a hyphen for the language tag (e.g. en-GB) while Transifex uses an
+        /// underscore (e.g. en_GB).
+        let normalizedLocaleCode = sourceLocale.replacingOccurrences(of: Self.TRANSIFEX_LANGUAGE_TAG_DELIMITER,
+                                                                     with: Self.IOS_LANGUAGE_TAG_DELIMITER)
+
+        self.sourceLocale = normalizedLocaleCode
         self.project = project
         self.logHandler = logHandler
 


### PR DESCRIPTION
This PR introduces a number of fixes that are outlined in each separate commit and in the CHANGELOG.

More specifically:

- Adds `--source-locale` option to `pull` command so that developers can specify
the source locale, if it's different than `en`. If not provided, the `pull`
logic default to the `en` source locale.
- Fixes an issue on `push` command where the unsupported SDK files were not
being excluded by the localization parsing logic.
- Addresses language tag discrepancy: In the `push` command, the
`--source-locale` option refers to the source locale of the Xcode project and
the format used by Xcode and iOS is different than the format used by Transifex
(e.g `en-US` instead of `en_US`). For that reason the source locale string is
now normalized before being passed to the exporter logic so that the latter can
always be able to export the source locale from the Xcode project.