### PR TITLE
White space ICU pluralization fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,3 +108,10 @@ the format used by Xcode and iOS is different than the format used by Transifex
 (e.g `en-US` instead of `en_US`). For that reason the source locale string is
 now normalized before being passed to the exporter logic so that the latter can
 always be able to export the source locale from the Xcode project.
+
+## Transifex Command Line Tool 2.1.2
+
+*October 11, 2023*
+
+- Fixes the issue where leading and trailing white space was being added around
+the extracted ICU pluralization rules.

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "2.1.1",
+        version: "2.1.2",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 

--- a/Sources/TXCliLib/XLIFFParser.swift
+++ b/Sources/TXCliLib/XLIFFParser.swift
@@ -163,7 +163,7 @@ extension TranslationUnit {
                 continue
             }
             
-            icuRules.append("\(pluralRule) { \(target) }")
+            icuRules.append("\(pluralRule) {\(target)}")
         }
         
         guard icuRules.count > 0 else {

--- a/Tests/TXCliTests/XLIFFParserTests.swift
+++ b/Tests/TXCliTests/XLIFFParserTests.swift
@@ -137,7 +137,7 @@ final class XLIFFParserTests: XCTestCase {
         XCTAssertTrue(pluralizationRules?.count == 3)
         
         let icuRule = results.first!.generateICURuleIfPossible()
-        let expectedIcuRule = "{cnt, plural, one { %d minute } other { %d minutes }}"
+        let expectedIcuRule = "{cnt, plural, one {%d minute} other {%d minutes}}"
         
         XCTAssertEqual(icuRule, expectedIcuRule)
     }
@@ -212,7 +212,7 @@ final class XLIFFParserTests: XCTestCase {
         XCTAssertTrue(result.pluralizationRules!.count == 3)
 
         let icuRule = result.generateICURuleIfPossible()
-        let expectedIcuRule = "{cnt, plural, one { %d minute } other { %d minutes }}"
+        let expectedIcuRule = "{cnt, plural, one {%d minute} other {%d minutes}}"
         
         XCTAssertEqual(icuRule, expectedIcuRule)
     }


### PR DESCRIPTION
Remove white space from the pluralization ICU rules

Removes leading and trailing white space from the pluralization ICU
rules that were being added when the XLIFF was being processed by the
CLI logic.

Updates unit tests.

---

Bump version to 2.1.2

* Bumps CLI version to 2.1.2.
* Updates the CHANGELOG.