### PR TITLE
Base SDK option in push command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,3 +115,10 @@ always be able to export the source locale from the Xcode project.
 
 - Fixes the issue where leading and trailing white space was being added around
 the extracted ICU pluralization rules.
+
+## Transifex Command Line Tool 2.1.3
+
+*October 30, 2023*
+
+- Adds `--base-sdk` option to `push` command so that developers can specify the
+sdk to be used when exporting localizations.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ Pushing translations to CDS: [
 ]...
 ```
 
+##### Specifying a base SDK
+
+The `txios-cli` tool calls the `xcodebuild` process to export the localizations
+using the `-exportLocalizations` option. When that happens, the system automatically
+picks the base SDK to be used (`iphoneos`, `macosx` etc).
+
+There have been cases where the base SDK is not picked up correctly by the `xcodebuild`
+process and a specific base SDK needs to be provided externally.
+
+If the `push` command fails with errors like "no such module 'UIKit'", the developer
+can manually specify the base SDK to be used using the `--base-sdk` option of the `push`
+command. For example, for iOS applications the option can be set to `--base-sdk iphoneos`.
+
 ##### Pushing pluralizations limitations
 
 Currently (version 0.1.0) pluralization is supported but only for cases where one variable is

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "2.1.2",
+        version: "2.1.3",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -80,6 +80,12 @@ You can either provide the Transifex token and secret via enviroment variables
     private var sourceLocale: String = "en"
 
     @Option(name: .long, help: """
+The name or path of the base SDK to be used when exporting project's localizations
+(e.g. iphoneos, macosx, iphoneos17.0, a path to the base SDK etc).
+""")
+    private var baseSDK: String?
+
+    @Option(name: .long, help: """
 Either the path to the project's .xcodeproj or .xcworkspace (e.g. ../MyProject/myproject.xcodeproj),
 or the path to the generated .xliff (e.g. ../en.xliff).
 """)
@@ -188,6 +194,7 @@ Emulate a content push, without doing actual changes.
         else {
             guard let locExporter = LocalizationExporter(sourceLocale: sourceLocale,
                                                          project: projectURL,
+                                                         baseSDK: baseSDK,
                                                          logHandler: logHandler) else {
                 logHandler.error("Failed to initialize localization exporter")
                 throw CommandError.exporterInitializationFailure

--- a/Sources/TXCliLib/LocalizationExporter.swift
+++ b/Sources/TXCliLib/LocalizationExporter.swift
@@ -21,6 +21,9 @@ public class LocalizationExporter {
     /// The temporary export file URL that will be used to store the exported localizations.
     private let exportURL: URL
     
+    /// The base SDK to be used.
+    private let baseSDK: String?
+
     private static let TEMP_FOLDER_PREFIX = "txios-cli-"
     
     private static let LOCALIZED_CONTENTS_FOLDER_NAME = "Localized Contents"
@@ -38,9 +41,11 @@ public class LocalizationExporter {
     /// - Parameters:
     ///   - sourceLocale: The source locale for the base localization
     ///   - project: The path to the project name (can be a relative path)
+    ///   - baseSDK: The base sdk to be used (optional)
     ///   - logHandler: Optional log handler
     public init?(sourceLocale: String,
                  project: URL,
+                 baseSDK: String?,
                  logHandler: TXLogHandler? = nil) {
         guard project.pathExtension == "xcodeproj"
                 || project.pathExtension == "xcworkspace" else {
@@ -57,6 +62,7 @@ public class LocalizationExporter {
         self.sourceLocale = normalizedLocaleCode
         self.project = project
         self.logHandler = logHandler
+        self.baseSDK = baseSDK
 
         let uuidString = UUID().uuidString
         let tempExportURLPath = LocalizationExporter.TEMP_FOLDER_PREFIX + uuidString
@@ -122,6 +128,9 @@ public class LocalizationExporter {
         process.arguments = [ "-exportLocalizations",
                               "-localizationPath", exportURL.path,
                               isProject ? "-project" : "-workspace", project.path]
+        if let baseSDK = baseSDK {
+            process.arguments?.append(contentsOf: [ "-sdk", baseSDK])
+        }
         process.standardOutput = outputPipe
         process.standardError = errorPipe
         


### PR DESCRIPTION
### Add base SDK option for push command

When exporting localizations via the `push` command, the default SDK
that was being used was the `macosx` one, resulting to errors when
the project included Swift packages using iOS frameworks.

In order to address this and provide more control to the developer, a
new option was introduced in the `push` command: `--base-sdk`.

The value of this option is passed as the `-sdk` option of the
`xcodebuild` process that is called to export the project's
localizations (via the `-exportLocalizations` option).

If no value is provided to this option, then the value of the `-sdk`
option is also not specified in the `xcodebuild` process and the default
SDK is picked by the system.

---

### Bump version to 2.1.3

* Bumps CLI version to 2.1.3.
* Updates the CHANGELOG.