### PR TITLE
Resolve --keep-translations argument issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,9 +116,11 @@ always be able to export the source locale from the Xcode project.
 - Fixes the issue where leading and trailing white space was being added around
 the extracted ICU pluralization rules.
 
-## Transifex Command Line Tool 2.1.3
+## Transifex Command Line Tool 2.1.4
 
-*October 30, 2023*
+*March 7, 2024*
 
-- Adds `--base-sdk` option to `push` command so that developers can specify the
-sdk to be used when exporting localizations.
+- Addresses issue with the `--keep-translations` option of the `push` command
+due to inversion. The option has been replaced by the `--delete-translations`
+option, in order to allow the underlying `keep_translations` meta flag to be
+set to `false`.

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/transifex/transifex-swift",
         "state": {
           "branch": null,
-          "revision": "aa97b51b642f3865cc9810d7e07ab2d33d6db215",
-          "version": "2.0.0"
+          "revision": "4490b3ed7abae304e9bb3fed02882320b1df224e",
+          "version": "2.0.1"
         }
       }
     ]

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "2.1.3",
+        version: "2.1.4",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -143,13 +143,13 @@ content to occurrences of existing strings instead of overwriting them.
     private var overrideOccurrences: Bool = false
 
     @Flag(name: .long, help: """
-If keep-translations: true (default), then preserve translations on source
-content updates.
-
-If keep-translations: false, then delete translations on source string content
+If delete-translations: true, then delete translations on source string content
 updates.
+
+If delete-translations: false (default), then preserve translations on source
+content updates.
 """)
-    private var keepTranslations: Bool = true
+    private var deleteTranslations: Bool = false
 
     @Flag(name: .long, help: """
 Emulate a content push, without doing actual changes.
@@ -293,7 +293,7 @@ Emulate a content push, without doing actual changes.
         let configuration = TXPushConfiguration(purge: purge,
                                                 overrideTags: overrideTags,
                                                 overrideOccurrences: overrideOccurrences,
-                                                keepTranslations: keepTranslations,
+                                                keepTranslations: !deleteTranslations,
                                                 dryRun: dryRun)
 
         logHandler.verbose("Push configuration: \(configuration.debugDescription)")


### PR DESCRIPTION
### Updates Transifex SDK package to v2.0.1

---

### Resolve --keep-translations argument issue

The `--keep-translations` argument of the `push` command was a boolean
flag that had a default value of `true`. This meant that if user did
not supply the `--keep-translations` argument to their `push` command
the value would be `true` and if they did, the value would also be
`true`, making it impossible for the `--keep-translations` flag to be
false.

In order to fix the issue, the argument has been replaced with the
inverse flag: `--delete-translations`. Its default value is `false` so
it behaves exactly as the `--keep-translations` before, if the argument
was not supplied (`keep_translations` is going to be set to `true`).

The difference is that now if this new argument is supplied, then the
underlying value of the `keep_translations` metadata will be `false`.

---

### Bump version to 2.1.4

* Bumps CLI version to 2.1.4.
* Updates the CHANGELOG.