### PR TITLE
String Catalog (.xcstrings) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,12 @@ always be able to export the source locale from the Xcode project.
 - Fixes the issue where leading and trailing white space was being added around
 the extracted ICU pluralization rules.
 
+## Transifex Command Line Tool 2.1.3
+
+*October 30, 2023*
+
+- Adds base SDK option for push command.
+
 ## Transifex Command Line Tool 2.1.4
 
 *March 7, 2024*
@@ -124,3 +130,10 @@ the extracted ICU pluralization rules.
 due to inversion. The option has been replaced by the `--delete-translations`
 option, in order to allow the underlying `keep_translations` meta flag to be
 set to `false`.
+
+## Transifex Command Line Tool 2.1.5
+
+*April 1, 2024*
+
+- Parses and processes the new `.xcstrings` files. Only supports simple
+"plural." rules for now.

--- a/README.md
+++ b/README.md
@@ -139,19 +139,19 @@ command. For example, for iOS applications the option can be set to `--base-sdk 
 
 ##### Pushing pluralizations limitations
 
-Currently (version 0.1.0) pluralization is supported but only for cases where one variable is
-used per pluralization rule. More advanced cases such as nested pluralization rules (for
-example: "%d out of %d values entered") will be supported in future releases.
+Generally, pluralization is supported but only for cases where one variable is used per pluralization rule.
 
-Also, at the moment of writing (version 0.1.0), the `.stringsdict` specification only supports
-plural types (`NSStringPluralRuleType`) which is the only possible value of the
-`NSStringFormatSpecTypeKey` key ([Ref](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html#//apple_ref/doc/uid/10000171i-CH16-SW4)).
+Both the existing `.stringsdict` and the newly introduced string catalog (`.xcstrings`) files are supported with some limitations mentioned below.
 
-If more rule types are added in the `.stringsdict` specification, the XLIFF parser must be
-updated in order to be able to extract them properly and to construct the ICU format out
-of them.
+We are actively working on adding support for more variations in future releases.
 
-Width Variants in `.stringsdict` files are also not currently supported ([Ref](https://help.apple.com/xcode/mac/current/#/devaf8b4090a)).
+###### String Catalogs (`.xcstrings`)
+
+Only plural rules are supported for string catalogs. Device variation [^1] and substitution rules are not currently supported.
+
+###### Strings Dictionary Files (`.stringsdict`)
+
+Only the plural type is supported (`NSStringPluralRuleType`) which is the only possible value of the `NSStringFormatSpecTypeKey` key [^2]. Width Variants are not currently supported [^3] [^4].
 
 #### Pulling
 
@@ -186,3 +186,8 @@ command can be simplified to:
 ## License
 
 Licensed under Apache License 2.0, see [LICENSE](LICENSE) file.
+
+[^1]: https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog#Vary-strings-by-device
+[^2]: https://developer.apple.com/documentation/xcode/localizing-strings-that-contain-plurals
+[^3]: https://help.apple.com/xcode/mac/current/#/devaf8b4090a
+[^4]: https://developer.apple.com/documentation/xcode/creating-width-and-device-variants-of-strings

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -245,8 +245,21 @@ Emulate a content push, without doing actual changes.
             
             // If the result contains string dict elements, convert them to
             // ICU format and use that as a source string
-            if let icuRule = result.generateICURuleIfPossible() {
-                sourceString = icuRule
+            switch result.generateICURuleIfPossible() {
+            case .success((let icuRule, let icuRuleType)):
+                // Only support plural rule type for now
+                if icuRuleType == .Plural {
+                    sourceString = icuRule
+                }
+            case .failure(let error):
+                switch error {
+                case .noRules:
+                    break
+                default:
+                    logHandler.error("Error: \(error)")
+                    // Do not add a translation unit in case of an error.
+                    continue
+                }
             }
             
             let translationUnit = TXSourceString(key: key,

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "2.1.4",
+        version: "2.1.5",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 


### PR DESCRIPTION
* Total refactor of the XLIFF parser logic.
* More readable and robust code that can handle out-of-order translation
units and special cases.
* XLIFF parser can now also parse `.xcstrings` files on top of the
existing `.strings` and `.stringsdict`.
* Only simple "plural." rules of `.xcstrings` files are parsed. The rest
of the rule types (device variations, substitutions) produce and log an
error and are not pushed to CDS.
* Improves XLIFF parsing logic.
* Adds unit test for simple `.xcstrings` plurals.
* Documents limitations.

---

### Bump version to 2.1.5

* Bumps CLI version to 2.1.5.
* Updates the CHANGELOG.