### PR TITLE
Full String Catalog support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,3 +137,11 @@ set to `false`.
 
 - Parses and processes the new `.xcstrings` files. Only supports simple
 "plural." rules for now.
+
+## Transifex Command Line Tool 2.1.6
+
+*May 29, 2024*
+
+- Adds full support for String Catalogs support.
+- Adds support for substitution phrases on old Strings Dictionary file format.
+- Updates unit tests.

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/transifex/transifex-swift",
         "state": {
           "branch": null,
-          "revision": "4490b3ed7abae304e9bb3fed02882320b1df224e",
-          "version": "2.0.1"
+          "revision": "b85d7c82966e820ac6e24cbf3f595b0dd02014aa",
+          "version": "2.0.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(name: "transifex",
                  url: "https://github.com/transifex/transifex-swift",
-                 from: "2.0.0"),
+                 from: "2.0.2"),
         .package(url: "https://github.com/apple/swift-argument-parser",
                  from: "0.3.0"),
         .package(url: "https://github.com/kiliankoe/CLISpinner",

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -247,10 +247,13 @@ Emulate a content push, without doing actual changes.
             // ICU format and use that as a source string
             switch result.generateICURuleIfPossible() {
             case .success((let icuRule, let icuRuleType)):
-                // Only support plural rule type for now
-                if icuRuleType == .Plural {
-                    sourceString = icuRule
+                if icuRuleType == TranslationUnit.ICURuleType.Other {
+                    logHandler.error("Error: ICU rule type could not be detected.")
+                    // Do not add a translation unit in case of a non-detected
+                    // ICU rule type.
+                    continue
                 }
+                sourceString = icuRule
             case .failure(let error):
                 switch error {
                 case .noRules:

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -42,7 +42,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "2.1.5",
+        version: "2.1.6",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 


### PR DESCRIPTION
### Full String Catalog support

With the introduction of the String Catalogs file format in Xcode 15,
developers have now the option to create localizations that vary by
device and/or by plural. On top of that, multiple tokens can be added in
a localized phrase (also known as substitutions) that can also support
the aforementioned variations.

In order to support all those new formats as well as the old
substitution rules found in the Strings Dictionary format
(`.stringsdict`), the advanced rules from the CLI tool are formatted as
an intermediate XML structure and pushed to CDS.

This commit adds this functionality so that complex variation rules can
be supported and displayed in the Transifex web interface.

More unit tests have been added to test those cases as well as edge-case
scenarios and existing unit tests have been improved.

---

### Bump version to 2.1.6

* Bumps CLI version to 2.1.6.
* Updates the CHANGELOG.

---

### Reference

The document below outlines how the implemented logic works both in the SDK (version 2.0.2) and in this update of the Transifex CLI tool (version 2.1.6): [Processing device variations and substitutions.pdf](https://github.com/transifex/transifex-swift-cli/files/15481468/Processing.device.variations.and.substitutions.pdf)