### PR TITLE
Release: 2.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,3 +145,16 @@ set to `false`.
 - Adds full support for String Catalogs support.
 - Adds support for substitution phrases on old Strings Dictionary file format.
 - Updates unit tests.
+
+## Transifex Command Line Tool 2.1.7
+
+*February 21, 2025*
+
+- Updates Transifex Swift package dependency to 2.0.7.
+- Defers logging while translations are fetched from CDS.
+- Reviews and updates help text on push / pull command options.
+- Introduces `--ignore-missing-locales` option in `pull` command.
+- Introduces `--extra-params` option in `push` command.
+- Executes `xcodebuild` from active developer directory.
+- Improves logging of `TXCDSError` and `CommandError`, offering human-readable
+error strings.

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/transifex/transifex-swift",
         "state": {
           "branch": null,
-          "revision": "b85d7c82966e820ac6e24cbf3f595b0dd02014aa",
-          "version": "2.0.2"
+          "revision": "f75ba230b938b95518a62cda364959de614bf4ef",
+          "version": "2.0.7"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(name: "transifex",
                  url: "https://github.com/transifex/transifex-swift",
-                 from: "2.0.2"),
+                 from: "2.0.7"),
         .package(url: "https://github.com/apple/swift-argument-parser",
                  from: "0.3.0"),
         .package(url: "https://github.com/kiliankoe/CLISpinner",

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -514,6 +514,9 @@ default to the 'en' source locale.
         
         logHandler.info("[high]Fetching translations from CDS...[end]")
         
+        // Defer log reporting until the pull logic completes
+        logHandler.deferred = true
+
         let spinner = Spinner(pattern: .dots, text: "Fetching")
         if !options.verbose {
             spinner.start()
@@ -536,7 +539,10 @@ default to the 'en' source locale.
         if !options.verbose {
             spinner.stopAndClear()
         }
-        
+
+        // Stop log message deferring and report any deferred logs
+        logHandler.deferred = false
+
         guard appErrors.count == 0 else {
             logHandler.error("Errors while fetching translations from CDS: \(appErrors)")
             throw CommandError.cdsPullFailure

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -76,18 +76,32 @@ You can either provide the Transifex token and secret via enviroment variables
 """
     )
     
-    @Option(name: .long, help: "Source locale")
+    @Option(name: .long, help: """
+Change the source locale if it is different than 'en'.
+
+e.g. --source-locale en_GB
+""")
     private var sourceLocale: String = "en"
 
     @Option(name: .long, help: """
-The name or path of the base SDK to be used when exporting project's localizations
-(e.g. iphoneos, macosx, iphoneos17.0, a path to the base SDK etc).
+Optional name or path of the base SDK to be used when exporting project's
+localizations.
+
+e.g.
+--base-sdk macosx
+--base-sdk iphoneos17.0
+--base-sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.2.sdk
 """)
     private var baseSDK: String?
 
     @Option(name: .long, help: """
-Either the path to the project's .xcodeproj or .xcworkspace (e.g. ../MyProject/myproject.xcodeproj),
-or the path to the generated .xliff (e.g. ../en.xliff).
+The absolute or relative path to the project's .xcodeproj , .xcworkspace or to
+the generated .xliff.
+
+e.g. 
+--project ../MyProject/myproject.xcodeproj
+--project ../MyProject/myproject.xcworkspace
+--project ../en.xliff
 """)
     private var project : String
     
@@ -97,14 +111,18 @@ Whether to keep the temporary folder that contains the generated .xcloc or not.
     private var keepTempFolder: Bool = false
     
     @Option(name: .long, parsing: .upToNextOption, help: """
-A list of optional global tags to be included in all source strings pushed to
-the CDS server.
+Optional space-separated list of global tags to be included in all source
+strings pushed to the CDS server.
+
+e.g. --append-tags master react
 """)
     private var appendTags: [String] = []
     
     @Option(name: .long, parsing: .upToNextOption, help: """
-An optional list of localizable files that the logic must exclude when
-processing the exported strings.
+Optional space-separated list of localizable files that the logic must exclude
+when processing the exported strings.
+
+e.g. --excluded-files target1/Info.strings target2/Info.strings
 """)
     private var excludedFiles: [String] = []
 
@@ -116,43 +134,45 @@ Control whether the keys of strings to be pushed should be hashed (true) or not
     private var hashKeys: Bool = false
 
     @Flag(name: .long, help: """
-If purge: true, then replace the entire resource content with the pushed content
-of this request.
+If --purge is specified, then the logic replaces the entire resource content
+with the pushed content of this request.
 
-If purge: false (default), then append the source content of this request to the
-existing resource content.
+If --purge is not specified, then the logic appends the source content of this
+request to the existing resource content.
 """)
     private var purge: Bool = false
 
     @Flag(name: .long, help: """
-If override-tags: true, then replace the existing string tags with the tags of
-this request.
+If --override-tags is specified, then the logic replaces the existing string
+tags with the tags of this request.
 
-If override-tags: false (default), then append tags from source content to tags
-of existing strings instead of overwriting them.
+If --override-tags is not specified, then the logic appends the tags from the 
+source content of this request to the tags of existing strings instead of
+overwriting them.
 """)
     private var overrideTags: Bool = false
 
     @Flag(name: .long, help: """
-If override-occurrences: true, then replace the existing string occurrences with
-the occurrences of this request.
+If --override-occurrences is specified, then the logic replaces the existing
+string occurrences with the occurrences of this request.
 
-If override-occurrences: false (default), then append occurrences from source
-content to occurrences of existing strings instead of overwriting them.
+If --override-occurrences is not specified, then the logic appends the
+occurrences from the source content of this request to the occurrences of the
+existing strings instead of overwriting them.
 """)
     private var overrideOccurrences: Bool = false
 
     @Flag(name: .long, help: """
-If delete-translations: true, then delete translations on source string content
-updates.
+If --delete-translations is specified, then the logic deletes the translations
+on source string content updates.
 
-If delete-translations: false (default), then preserve translations on source
-content updates.
+If --delete-translation is not specified, then the logic preserves the
+translations on source content updates.
 """)
     private var deleteTranslations: Bool = false
 
     @Flag(name: .long, help: """
-Emulate a content push, without doing actual changes.
+Emulate a content push, without performing any actual changes.
 """)
     private var dryRun: Bool = false
 
@@ -457,9 +477,12 @@ or via the --token parameter.
     )
 
     @Option(name: .long, parsing: .upToNextOption, help: """
-A list of the available locales that the application supports and will be
-downloaded from CDS. If both source and target locales are provided in the list,
-they will also be requested from CDS.
+A space-separated list of the available locales that the application supports 
+and will be downloaded from CDS. 
+If both source and target locales are provided in the list, they will also be
+requested from CDS.
+
+e.g. --translated-locales en el fr
 """)
     private var translatedLocales: [String]
     
@@ -467,29 +490,37 @@ they will also be requested from CDS.
 The folder to be used to store the generated translations file. You can use
 either a relative or an absolute path. If the folder doesn't exist, the tool
 will try to create it (alongside any intermediate folders).
+
+e.g. --output ~/Desktop/
 """)
     private var output: String
     
     @Option(name: .long, parsing: .upToNextOption, help: """
-If set, only the strings that have all of the given tags will be downloaded.
+Optional space-separated list that if provided, only the strings containing
+all of the specified tags will be downloaded.
 
 This option can be used alongside the --with-status-only option.
+
+e.g. --with-tags-only master react
 """)
     private var withTagsOnly: [String] = []
     
     @Option(name: .long, help: """
-If set, only the strings that have the provided status assigned will be
-downloaded.
+Optional value that if provided, only the strings that have the specified
+status assigned will be downloaded.
 
 This option can be used alongside the --with-tags-only option.
+
+e.g. --with-status-only translated
 """)
     private var withStatusOnly: String?
 
     @Option(name: .long, help: """
-Provide a source locale if it is different than 'en'. Otherwise the logic will
-default to the 'en' source locale.
+Change the source locale if it is different than 'en'.
+
+e.g. --source-locale en_GB
 """)
-    private var sourceLocale: String?
+    private var sourceLocale: String = "en"
 
     func run() throws {
         let logHandler = CliLogHandler()

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -376,61 +376,8 @@ Warning: Empty key on source string:
                                  trailingLine: true)
                 continue
             }
-            switch error {
-            case .noDataToBeSent:
-                logHandler.error("Error encoding source strings",
-                                 trailingLine: true)
-
-            case .invalidCDSURL:
-                logHandler.error("Error: Invalid CDS host URL:",
-                                 trailingLine: true)
-
-            case .failedSerialization(let err):
-                logHandler.error("Error while serializing translations: \(err)",
-                                 trailingLine: true)
-
-            case .requestFailed(let err):
-                logHandler.error("Error pushing strings: \(err)",
-                                 trailingLine: true)
-
-            case .invalidHTTPResponse:
-                logHandler.error("Error pushing strings: Not a valid HTTP response",
-                                 trailingLine: true)
-
-            case .serverError(let statusCode):
-                logHandler.error("HTTP Status error while pushing strings: \(statusCode)",
-                                 trailingLine: true)
-
-            case .noData:
-                logHandler.error("Error: No data received while pushing strings",
-                                 trailingLine: true)
-
-            case .nonParsableResponse:
-                logHandler.error("Error while decoding CDS push response",
-                                 trailingLine: true)
-
-            case .failedJobRequest:
-                logHandler.error("Error: Fetch job status request failed",
-                                 trailingLine: true)
-
-            case .maxRetriesReached:
-                logHandler.info("[prompt]Strings are queued for processing[end]")
-
-            case .jobError(status: let status,
-                           code: let code,
-                           title: let title,
-                           detail: let detail,
-                           source: let source):
-                logHandler.error("""
-Error: \(title) (\(status) - \(code)):
-Detail: \(detail)
-Source: \(source)
-""", trailingLine: true)
-
-            default:
-                logHandler.error("Error while pushing source strings to CDS",
-                                 trailingLine: true)
-            }
+            logHandler.error("\(error)",
+                             trailingLine: true)
         }
 
         if pushResult {

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -205,6 +205,25 @@ translations on source content updates.
 Emulate a content push, without performing any actual changes.
 """)
     private var dryRun: Bool = false
+    
+    @Option(name: .long,
+            help: """
+Optional extra parameters to be passed on the internal xcodebuild call.
+
+By default only the following parameters are used:
+
+* -exportLocalizations
+* -localizationPath
+* -project / -workspace
+* -sdk (if --base-sdk option is set)
+
+Make sure that you pass this option with an = operator, as shown in the example
+below.
+
+e.g. 
+--extra-params="-quiet -scheme my-scheme -configuration Release"
+""")
+    private var extraParams: String?
 
     func run() throws {
         let logHandler = CliLogHandler()
@@ -245,6 +264,7 @@ Emulate a content push, without performing any actual changes.
             guard let locExporter = LocalizationExporter(sourceLocale: sourceLocale,
                                                          project: projectURL,
                                                          baseSDK: baseSDK,
+                                                         extraParams: extraParams,
                                                          logHandler: logHandler) else {
                 logHandler.error("Failed to initialize localization exporter")
                 throw CommandError.exporterInitializationFailure

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -13,7 +13,7 @@ import Foundation
 import CLISpinner
 
 /// All possible error codes that might trigger a failure during the execution of a TXCli command.
-enum CommandError : Error {
+enum CommandError : Error, CustomStringConvertible {
     case missingToken
     case missingSecret
     case exporterInitializationFailure
@@ -26,6 +26,36 @@ enum CommandError : Error {
     case outputDirectoryCreationFailure
     case outputFileWritingFailure
     case cdsCacheInvalidationFailure
+    
+    // Human-readable error codes
+    public var description: String {
+        switch self {
+        case .missingToken:
+            return "Token is missing"
+        case .missingSecret:
+            return "Secret is missing"
+        case .exporterInitializationFailure:
+            return "Exporter failed to initialize"
+        case .exportingFailure:
+            return "Exporting failed"
+        case .xliffParserInitializationFailure:
+            return "XLIFF parser failed to initialze"
+        case .xliffParsingFailure:
+            return "XLIFF parsong failed"
+        case .cdsPushFailure:
+            return "Push to CDS failed"
+        case .cdsPullFailure:
+            return "Pull from CDS failed"
+        case .translationsEncodingFailure:
+            return "Encoding failure encountered when processing translations"
+        case .outputDirectoryCreationFailure:
+            return "Creation of output directory failed"
+        case .outputFileWritingFailure:
+            return "Writing to the output file failed"
+        case .cdsCacheInvalidationFailure:
+            return "CDS cache invalidation failed"
+        }
+    }
 }
 
 /// Base command of TXCli app, this command describes the basic usage of the CLI app and lists all

--- a/Sources/TXCli/main.swift
+++ b/Sources/TXCli/main.swift
@@ -72,7 +72,7 @@ that can be bundled with the iOS application.
 The tool can be also used to force CDS cache invalidation so that the next pull
 command will fetch fresh translations from CDS.
 """,
-        version: "2.1.6",
+        version: "2.1.7",
         subcommands: [Push.self, Pull.self, Invalidate.self])
 }
 

--- a/Sources/TXCliLib/CliLogHandler.swift
+++ b/Sources/TXCliLib/CliLogHandler.swift
@@ -14,6 +14,20 @@ public class CliLogHandler: TXLogHandler {
     /// (verbose: true) or not (verbose: false).
     public var verbose: Bool = false
     
+    /// Flag that controls whether the log statements will be logged immediately in the console
+    /// (`deferred: false`) or they will be collected and reported when the value of that flag is set
+    /// back from `true` to `false`.
+    public var deferred = false {
+        didSet {
+            if deferred == false {
+                defferedLogs.forEach { log($0) }
+                defferedLogs.removeAll()
+            }
+        }
+    }
+
+    private var defferedLogs: [String] = []
+
     public init() { }
     
     public func info(_ message: String) {
@@ -61,6 +75,10 @@ public class CliLogHandler: TXLogHandler {
     }
     
     private func log(_ message: String) {
+        guard !deferred else {
+            defferedLogs.append(message)
+            return
+        }
         print(CliSyntaxColor.format(message))
     }
 }

--- a/Sources/TXCliLib/LocalizationExporter.swift
+++ b/Sources/TXCliLib/LocalizationExporter.swift
@@ -24,6 +24,9 @@ public class LocalizationExporter {
     /// The base SDK to be used.
     private let baseSDK: String?
 
+    /// Extra parameters provided by the developer for the xcodebuild call.
+    private let extraParams: String?
+
     private static let TEMP_FOLDER_PREFIX = "txios-cli-"
     
     private static let LOCALIZED_CONTENTS_FOLDER_NAME = "Localized Contents"
@@ -42,10 +45,12 @@ public class LocalizationExporter {
     ///   - sourceLocale: The source locale for the base localization
     ///   - project: The path to the project name (can be a relative path)
     ///   - baseSDK: The base sdk to be used (optional)
+    ///   - extraParams: String containing extra parameters for the xcodebuild call (optional)
     ///   - logHandler: Optional log handler
     public init?(sourceLocale: String,
                  project: URL,
                  baseSDK: String?,
+                 extraParams: String?,
                  logHandler: TXLogHandler? = nil) {
         guard project.pathExtension == "xcodeproj"
                 || project.pathExtension == "xcworkspace" else {
@@ -63,6 +68,7 @@ public class LocalizationExporter {
         self.project = project
         self.logHandler = logHandler
         self.baseSDK = baseSDK
+        self.extraParams = extraParams
 
         let uuidString = UUID().uuidString
         let tempExportURLPath = LocalizationExporter.TEMP_FOLDER_PREFIX + uuidString
@@ -138,6 +144,8 @@ public class LocalizationExporter {
                 "-sdk", baseSDK
             ])
         }
+        extraParams?.components(separatedBy: " ").forEach {
+            process.arguments?.append($0)
         }
         process.standardOutput = outputPipe
         process.standardError = errorPipe

--- a/Sources/TXCliLib/LocalizationExporter.swift
+++ b/Sources/TXCliLib/LocalizationExporter.swift
@@ -117,7 +117,7 @@ public class LocalizationExporter {
     ///
     /// - Returns: The URL to the source locale XLIFF file, nil in case of an error.
     public func export() -> URL? {
-        logHandler?.verbose("[prompt]Exporting localizations for project \(project) to[end] [file]\(exportURL.path)[end][prompt]...[end]")
+        logHandler?.verbose("[prompt]Exporting localizations for project \(project.path) to[end] [file]\(exportURL.path)[end][prompt]...[end]")
         
         let isProject = project.pathExtension == "xcodeproj"
         let outputPipe = Pipe()
@@ -133,7 +133,13 @@ public class LocalizationExporter {
         }
         process.standardOutput = outputPipe
         process.standardError = errorPipe
-        
+
+        logHandler?.verbose("""
+Command line invocation:
+    \(xcodebuildURL.path) \(process.arguments?.joined(separator: " ") ?? "")
+
+""")
+
         do {
             try process.run()
         }
@@ -141,6 +147,7 @@ public class LocalizationExporter {
             logHandler?.error("""
 Error executing xcodebuild:
 \(error)
+
 """)
             return nil
         }
@@ -165,8 +172,9 @@ Error executing xcodebuild:
 
         if output.count > 0 {
             logHandler?.verbose("""
-[warn]xcodebuild output:[end]
-[warn]\(output.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines))[end]
+xcodebuild output:
+[cyan]\(output.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines))[end]
+
 """)
         }
 
@@ -174,8 +182,10 @@ Error executing xcodebuild:
 
         if error.count > 0 {
             logHandler?.verbose("""
+
 xcodebuild error:
-\(error.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines))
+[warn]\(error.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines))[end]
+
 """)
         }
         


### PR DESCRIPTION
- Updates Transifex Swift package dependency to 2.0.7.
- Defers logging while translations are fetched from CDS.
- Reviews and updates help text on push / pull command options.
- Introduces `--ignore-missing-locales` option in `pull` command.
- Introduces `--extra-params` option in `push` command.
- Executes `xcodebuild` from active developer directory.
- Improves logging of `TXCDSError` and `CommandError`, offering human-readable
error strings.